### PR TITLE
Group Join CRUD 기능 구현 완료

### DIFF
--- a/src/main/java/com/simbongsa/global/EntityFacade.java
+++ b/src/main/java/com/simbongsa/global/EntityFacade.java
@@ -4,11 +4,14 @@ import com.simbongsa.global.common.apiPayload.code.statusEnums.ErrorStatus;
 import com.simbongsa.global.common.exception.GeneralHandler;
 import com.simbongsa.group.entity.Group;
 import com.simbongsa.group.repository.GroupRepository;
+import com.simbongsa.group_join.entity.GroupJoin;
+import com.simbongsa.group_join.repository.GroupJoinRepository;
 import com.simbongsa.member.entity.Member;
 import com.simbongsa.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -16,6 +19,7 @@ import java.util.Optional;
 public class EntityFacade {
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
+    private final GroupJoinRepository groupJoinRepository;
     public Member getMember(Long memberId) {
         Optional<Member> memberById = memberRepository.findById(memberId);
         if (memberById.isEmpty())
@@ -28,5 +32,23 @@ public class EntityFacade {
         if (groupById.isEmpty())
             throw new GeneralHandler(ErrorStatus.GROUP_NOT_FOUND);
         return groupById.get();
+    }
+
+    public GroupJoin getGroupJoin(Long groupJoinId) {
+        Optional<GroupJoin> groupJoinById = groupJoinRepository.findById(groupJoinId);
+        if (groupJoinById.isEmpty())
+            throw new GeneralHandler(ErrorStatus.GROUP_JOIN_NOT_FOUND);
+        return groupJoinById.get();
+    }
+
+    public List<GroupJoin> getGroupJoinsByMemberId(Long memberId) {
+        return groupJoinRepository.findByMember_Id(memberId);
+    }
+
+    public List<GroupJoin> getGroupJoinsByGroupId(Long groupId) {
+        return groupJoinRepository.findByGroup_Id(groupId);
+    }
+    public Optional<GroupJoin> getGroupJoinByGroupIdAndMemberId(Long groupId, Long memberId) {
+        return groupJoinRepository.findByGroup_IdAndMember_Id(groupId, memberId);
     }
 }

--- a/src/main/java/com/simbongsa/global/common/apiPayload/code/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/simbongsa/global/common/apiPayload/code/statusEnums/ErrorStatus.java
@@ -24,9 +24,16 @@ public enum ErrorStatus implements BaseCode {
     DUPLICATED_USERID(HttpStatus.UNAUTHORIZED, "USER4011", "이미 존재하는 사용자 ID입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER4012", "사용자 비밀번호가 일치하지 않습니다"),
     SESSION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER4013", "존재하지 않는 유효한 세션입니다."),
+    USER_FORBIDDEN(HttpStatus.FORBIDDEN, "USER403", "사용자에게 권한이 없습니다."),
+
 
     // 그룹 관련
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404", "그룹을 찾을 수 없습니다."),
+    GROUP_FULL(HttpStatus.BAD_REQUEST, "GROUP4001", "그룹 인원이 가득 찼습니다."),
+    
+    // 그룹 지원 관련
+    GROUP_JOIN_CONFLICT(HttpStatus.CONFLICT, "GROUP_JOIN409", "지원 신청이 이미 존재합니다."),
+    GROUP_JOIN_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP_JOIN4042", "그룹 신청을 찾을 수 없습니다."),
 
     // 공지 관련
     NOTICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTICE4001", "존재하지 않는 공지 ID입니다."),

--- a/src/main/java/com/simbongsa/global/common/constant/JoinDecide.java
+++ b/src/main/java/com/simbongsa/global/common/constant/JoinDecide.java
@@ -1,0 +1,5 @@
+package com.simbongsa.global.common.constant;
+
+public enum JoinDecide {
+    ACCEPT, REJECT
+}

--- a/src/main/java/com/simbongsa/global/common/constant/JoinType.java
+++ b/src/main/java/com/simbongsa/global/common/constant/JoinType.java
@@ -1,0 +1,5 @@
+package com.simbongsa.global.common.constant;
+
+public enum JoinType {
+    JOIN, CANCEL
+}

--- a/src/main/java/com/simbongsa/global/config/QuerydslConfig.java
+++ b/src/main/java/com/simbongsa/global/config/QuerydslConfig.java
@@ -1,0 +1,17 @@
+package com.simbongsa.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    public EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);}
+}

--- a/src/main/java/com/simbongsa/group/controller/GroupController.java
+++ b/src/main/java/com/simbongsa/group/controller/GroupController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/group")
+@RequestMapping("/groups")
 public class GroupController {
 
     private final GroupService groupService;
@@ -91,4 +91,10 @@ public class GroupController {
         groupService.deleteGroup(memberId, groupId);
         return CustomApiResponse.onSuccess();
     }
+    
+    //TODO: 그룹 인원 리스트 불러오기
+
+    //TODO: 강퇴
+
+
 }

--- a/src/main/java/com/simbongsa/group/entity/Group.java
+++ b/src/main/java/com/simbongsa/group/entity/Group.java
@@ -34,7 +34,7 @@ public class Group extends BaseEntity {
     @Column(nullable = false)
     private GroupStatus groupStatus;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_leader_id")
     private Member groupLeader;
 }

--- a/src/main/java/com/simbongsa/group/entity/Group.java
+++ b/src/main/java/com/simbongsa/group/entity/Group.java
@@ -37,4 +37,8 @@ public class Group extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_leader_id")
     private Member groupLeader;
+
+    public void increaseCurrentPeople() {
+        this.currentPeople++;
+    }
 }

--- a/src/main/java/com/simbongsa/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/simbongsa/group/service/GroupServiceImpl.java
@@ -50,6 +50,7 @@ public class GroupServiceImpl implements GroupService{
         Member member = entityFacade.getMember(memberId);
         Group group = groupCreateReq.mapCreateReqToGroup(member);
         Group saveGroup = groupRepository.save(group);
+        //GroupUser에 방장 값을 넣어줘야 하는가?
 
         return saveGroup.getId();
     }
@@ -68,7 +69,7 @@ public class GroupServiceImpl implements GroupService{
             group.setIntroduction(groupUpdateReq.introduction());
         if (groupUpdateReq.maxPeople() != null) {
             if (group.getCurrentPeople() > groupUpdateReq.maxPeople())
-                throw new GeneralHandler(ErrorStatus._BAD_REQUEST);
+                throw new GeneralHandler(ErrorStatus.GROUP_FULL);
             group.setMaxPeople(groupUpdateReq.maxPeople());
         }
         if (groupUpdateReq.groupStatus() != null)
@@ -84,6 +85,6 @@ public class GroupServiceImpl implements GroupService{
 
     private void checkMemberRole(Long leaderId, Long memberId) {
         if (!leaderId.equals(memberId))
-            throw new GeneralHandler(ErrorStatus._UNAUTHORIZED);
+            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
     }
 }

--- a/src/main/java/com/simbongsa/group_join/JoinType.java
+++ b/src/main/java/com/simbongsa/group_join/JoinType.java
@@ -1,5 +1,0 @@
-package com.simbongsa.group_join;
-
-public enum JoinType {
-    JOIN, CANCEL
-}

--- a/src/main/java/com/simbongsa/group_join/controller/GroupJoinController.java
+++ b/src/main/java/com/simbongsa/group_join/controller/GroupJoinController.java
@@ -1,0 +1,72 @@
+package com.simbongsa.group_join.controller;
+
+import com.simbongsa.global.common.apiPayload.CustomApiResponse;
+import com.simbongsa.group_join.dto.req.GroupJoinApplyReq;
+import com.simbongsa.group_join.dto.req.GroupJoinDecideReq;
+import com.simbongsa.group_join.dto.res.GroupJoinMyRes;
+import com.simbongsa.group_join.dto.res.GroupJoinRes;
+import com.simbongsa.group_join.service.GroupJoinService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/group-joins")
+public class GroupJoinController {
+    private final GroupJoinService groupJoinService;
+
+    /**
+     * 참가 신청
+     * @param memberId 신청자 Id
+     * @param groupJoinApplyReq 신청할 그룹, 상태
+     * @return ?
+     */
+    @PostMapping
+    public CustomApiResponse<?> applyJoin(@AuthenticationPrincipal Long memberId,
+                                          @RequestBody GroupJoinApplyReq groupJoinApplyReq) {
+        groupJoinService.applyJoin(memberId, groupJoinApplyReq);
+        return CustomApiResponse.onSuccess();
+    }
+
+    /**
+     * 참가 결정
+     * @param memberId 방장 Id
+     * @param groupJoinDecideReq 그룹 조인 Id, 수락/거절
+     * @return ?
+     */
+    @PostMapping("/{groupId}/decision")
+    public CustomApiResponse<?> decideJoin(@AuthenticationPrincipal Long memberId,
+                                           @RequestBody GroupJoinDecideReq groupJoinDecideReq) {
+        groupJoinService.decideJoin(memberId, groupJoinDecideReq);
+        return CustomApiResponse.onSuccess();
+    }
+
+    /**
+     * 지원자 현황
+     * @param memberId 유저 Id
+     * @param groupId 그룹 Id
+     * @return 지원자 신청 현황
+     */
+    @GetMapping("/{groupId}/applications")
+    public CustomApiResponse<List<GroupJoinRes>> getJoin(@AuthenticationPrincipal Long memberId,
+                                        @PathVariable Long groupId) {
+        List<GroupJoinRes> groupJoinList = groupJoinService.getGroupJoinList(memberId, groupId);
+        return CustomApiResponse.onSuccess(groupJoinList);
+    }
+
+    /**
+     * 내 지원 현황
+     * @param memberId 유저 Id
+     * @return 내 지원 현황
+     */
+    @GetMapping("/my-applications")
+    public CustomApiResponse<List<GroupJoinMyRes>> getJoinList(@AuthenticationPrincipal Long memberId) {
+        List<GroupJoinMyRes> myGroupJoinList = groupJoinService.getMyGroupJoinList(memberId);
+        return CustomApiResponse.onSuccess(myGroupJoinList);
+    }
+}

--- a/src/main/java/com/simbongsa/group_join/dto/req/GroupJoinApplyReq.java
+++ b/src/main/java/com/simbongsa/group_join/dto/req/GroupJoinApplyReq.java
@@ -1,0 +1,12 @@
+package com.simbongsa.group_join.dto.req;
+
+import com.simbongsa.global.common.constant.JoinType;
+import jakarta.validation.constraints.NotNull;
+
+public record GroupJoinApplyReq(
+        @NotNull
+        Long groupId,
+        @NotNull
+        JoinType joinType
+) {
+}

--- a/src/main/java/com/simbongsa/group_join/dto/req/GroupJoinDecideReq.java
+++ b/src/main/java/com/simbongsa/group_join/dto/req/GroupJoinDecideReq.java
@@ -1,0 +1,12 @@
+package com.simbongsa.group_join.dto.req;
+
+import com.simbongsa.global.common.constant.JoinDecide;
+import jakarta.validation.constraints.NotNull;
+
+public record GroupJoinDecideReq(
+        @NotNull
+        Long groupJoinId,
+        @NotNull
+        JoinDecide joinDecide
+) {
+}

--- a/src/main/java/com/simbongsa/group_join/dto/res/GroupJoinMyRes.java
+++ b/src/main/java/com/simbongsa/group_join/dto/res/GroupJoinMyRes.java
@@ -1,0 +1,22 @@
+package com.simbongsa.group_join.dto.res;
+
+import com.simbongsa.group.entity.Group;
+import com.simbongsa.group_join.entity.GroupJoin;
+import lombok.Builder;
+
+@Builder
+public record GroupJoinMyRes(
+        Long groupJoinId,
+        Long groupId,
+        String name
+) {
+
+    public static GroupJoinMyRes mapGroupJoinToMyRes(GroupJoin groupJoin) {
+        Group group = groupJoin.getGroup();
+        return GroupJoinMyRes.builder()
+                .groupJoinId(groupJoin.getId())
+                .groupId(group.getId())
+                .name(group.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/simbongsa/group_join/dto/res/GroupJoinRes.java
+++ b/src/main/java/com/simbongsa/group_join/dto/res/GroupJoinRes.java
@@ -1,0 +1,26 @@
+package com.simbongsa.group_join.dto.res;
+
+import com.simbongsa.group_join.entity.GroupJoin;
+import com.simbongsa.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record GroupJoinRes(
+        Long groupJoinId,
+        Long memberId,
+        String nickname,
+        String introduction,
+        String profileImg
+) {
+
+    public static GroupJoinRes mapMemberToJoinRes(GroupJoin groupJoin) {
+        Member member = groupJoin.getMember();
+        return GroupJoinRes.builder()
+                .groupJoinId(groupJoin.getId())
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .profileImg(member.getProfileImg())
+                .build();
+    }
+}

--- a/src/main/java/com/simbongsa/group_join/entity/GroupJoin.java
+++ b/src/main/java/com/simbongsa/group_join/entity/GroupJoin.java
@@ -2,7 +2,7 @@ package com.simbongsa.group_join.entity;
 
 import com.simbongsa.global.common.entity.BaseEntity;
 import com.simbongsa.group.entity.Group;
-import com.simbongsa.group_join.JoinType;
+import com.simbongsa.global.common.constant.JoinType;
 import com.simbongsa.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/simbongsa/group_join/entity/GroupJoin.java
+++ b/src/main/java/com/simbongsa/group_join/entity/GroupJoin.java
@@ -20,7 +20,7 @@ public class GroupJoin extends BaseEntity {
     @Column(name = "group_join_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     private Group group;
 

--- a/src/main/java/com/simbongsa/group_join/repository/GroupJoinRepository.java
+++ b/src/main/java/com/simbongsa/group_join/repository/GroupJoinRepository.java
@@ -4,6 +4,12 @@ import com.simbongsa.group_join.entity.GroupJoin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface GroupJoinRepository extends JpaRepository<GroupJoin, Long> {
+    Optional<GroupJoin> findByGroup_IdAndMember_Id(Long groupId, Long memberId);
+    List<GroupJoin> findByMember_Id(Long memberId);
+    List<GroupJoin> findByGroup_Id(Long groupId);
 }

--- a/src/main/java/com/simbongsa/group_join/service/GroupJoinService.java
+++ b/src/main/java/com/simbongsa/group_join/service/GroupJoinService.java
@@ -1,0 +1,18 @@
+package com.simbongsa.group_join.service;
+
+import com.simbongsa.group_join.dto.req.GroupJoinApplyReq;
+import com.simbongsa.group_join.dto.req.GroupJoinDecideReq;
+import com.simbongsa.group_join.dto.res.GroupJoinMyRes;
+import com.simbongsa.group_join.dto.res.GroupJoinRes;
+
+import java.util.List;
+
+public interface GroupJoinService {
+    void applyJoin(Long memberId, GroupJoinApplyReq groupJoinApplyReq);
+
+    void decideJoin(Long memberId, GroupJoinDecideReq groupJoinDecideReq);
+
+    List<GroupJoinRes> getGroupJoinList(Long memberId, Long groupId);
+
+    List<GroupJoinMyRes> getMyGroupJoinList(Long memberId);
+}

--- a/src/main/java/com/simbongsa/group_join/service/GroupJoinServiceImpl.java
+++ b/src/main/java/com/simbongsa/group_join/service/GroupJoinServiceImpl.java
@@ -1,0 +1,104 @@
+package com.simbongsa.group_join.service;
+
+import com.simbongsa.global.EntityFacade;
+import com.simbongsa.global.common.apiPayload.code.statusEnums.ErrorStatus;
+import com.simbongsa.global.common.constant.GroupStatus;
+import com.simbongsa.global.common.exception.GeneralHandler;
+import com.simbongsa.group.entity.Group;
+import com.simbongsa.group_join.dto.req.GroupJoinApplyReq;
+import com.simbongsa.group_join.dto.req.GroupJoinDecideReq;
+import com.simbongsa.group_join.dto.res.GroupJoinMyRes;
+import com.simbongsa.group_join.dto.res.GroupJoinRes;
+import com.simbongsa.group_join.entity.GroupJoin;
+import com.simbongsa.group_join.repository.GroupJoinRepository;
+import com.simbongsa.group_user.entity.GroupUser;
+import com.simbongsa.group_user.repository.GroupUserRepository;
+import com.simbongsa.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class GroupJoinServiceImpl implements GroupJoinService{
+    private final EntityFacade entityFacade;
+    private final GroupJoinRepository groupJoinRepository;
+    private final GroupUserRepository groupUserRepository;
+    @Override
+    public void applyJoin(Long memberId, GroupJoinApplyReq groupJoinApplyReq) {
+        Member member = entityFacade.getMember(memberId);
+        Group group = entityFacade.getGroup(groupJoinApplyReq.groupId());
+
+        Optional<GroupJoin> groupJoinByGroupIdAndMemberId = entityFacade.getGroupJoinByGroupIdAndMemberId(group.getId(), memberId);
+        switch (groupJoinApplyReq.joinType()) {
+            case JOIN -> {
+                //중복 지원 체크
+                groupJoinByGroupIdAndMemberId.ifPresent(val -> {
+                    log.error("Value is present: " + val);
+                    throw new GeneralHandler(ErrorStatus.GROUP_JOIN_CONFLICT);
+                });
+
+                /**
+                 * 지원 완료
+                 * PUBLIC: 즉시 그룹에 합류(maxPeople > currentPeople 일 때)
+                 * PRIVATE: 지원 완료
+                 */
+                if (group.getGroupStatus().equals(GroupStatus.PUBLIC)) {
+                    if (group.getMaxPeople() <= group.getCurrentPeople())
+                        throw new GeneralHandler(ErrorStatus.GROUP_FULL);
+                    joinGroup(group, member);
+                } else {
+                    GroupJoin groupJoin = new GroupJoin(null, group, member, groupJoinApplyReq.joinType());
+                    groupJoinRepository.save(groupJoin);
+                }
+            }
+            case CANCEL ->
+                //지원 이력 체크
+                groupJoinByGroupIdAndMemberId.ifPresentOrElse(
+                        groupJoinRepository::delete,
+                        () -> {
+                            log.error("Value is not found");
+                            throw new GeneralHandler(ErrorStatus.GROUP_JOIN_NOT_FOUND);
+                        }
+                );
+        }
+    }
+
+    @Override
+    public void decideJoin(Long memberId, GroupJoinDecideReq groupJoinDecideReq) {
+        //지원 이력 삭제
+        GroupJoin groupJoin = entityFacade.getGroupJoin(groupJoinDecideReq.groupJoinId());
+        if (!groupJoin.getGroup().getGroupLeader().getId().equals(memberId))
+            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
+        groupJoinRepository.delete(groupJoin);
+        joinGroup(groupJoin.getGroup(), groupJoin.getMember());
+    }
+
+    @Override
+    public List<GroupJoinRes> getGroupJoinList(Long memberId, Long groupId) {
+        List<GroupJoin> groupJoinsByGroupId = entityFacade.getGroupJoinsByGroupId(groupId);
+        return groupJoinsByGroupId.stream()
+                .map(GroupJoinRes::mapMemberToJoinRes)
+                .toList();
+    }
+
+    @Override
+    public List<GroupJoinMyRes> getMyGroupJoinList(Long memberId) {
+        List<GroupJoin> groupJoinsByMemberId = entityFacade.getGroupJoinsByMemberId(memberId);
+        return groupJoinsByMemberId.stream()
+                .map(GroupJoinMyRes::mapGroupJoinToMyRes)
+                .toList();
+    }
+
+    private void joinGroup(Group group, Member member) {
+        GroupUser groupUser = new GroupUser(null, group, member);
+        groupUserRepository.save(groupUser);
+        group.increaseCurrentPeople();
+    }
+}

--- a/src/main/java/com/simbongsa/group_user/repository/GroupUserRepository.java
+++ b/src/main/java/com/simbongsa/group_user/repository/GroupUserRepository.java
@@ -4,6 +4,9 @@ import com.simbongsa.group_user.entity.GroupUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
+    Optional<GroupUser> findByGroup_IdAndMember_Id(Long groupId, Long memberId);
 }

--- a/src/test/java/com/simbongsa/group_join/service/GroupJoinServiceTest.java
+++ b/src/test/java/com/simbongsa/group_join/service/GroupJoinServiceTest.java
@@ -1,0 +1,256 @@
+package com.simbongsa.group_join.service;
+
+import com.simbongsa.global.common.constant.*;
+import com.simbongsa.global.common.exception.GeneralHandler;
+import com.simbongsa.group.dto.req.GroupCreateReq;
+import com.simbongsa.group.entity.Group;
+import com.simbongsa.group.repository.GroupRepository;
+import com.simbongsa.group.service.GroupService;
+import com.simbongsa.group_join.dto.req.GroupJoinApplyReq;
+import com.simbongsa.group_join.dto.req.GroupJoinDecideReq;
+import com.simbongsa.group_join.dto.res.GroupJoinMyRes;
+import com.simbongsa.group_join.dto.res.GroupJoinRes;
+import com.simbongsa.group_join.entity.GroupJoin;
+import com.simbongsa.group_join.repository.GroupJoinRepository;
+import com.simbongsa.group_user.entity.GroupUser;
+import com.simbongsa.group_user.repository.GroupUserRepository;
+import com.simbongsa.member.entity.Member;
+import com.simbongsa.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Transactional
+@SpringBootTest
+class GroupJoinServiceTest {
+    @Autowired
+    private GroupService groupService;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private GroupJoinService groupJoinService;
+    @Autowired
+    private GroupJoinRepository groupJoinRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GroupUserRepository groupUserRepository;
+
+    public Long memberId_01;
+    public Long memberId_02;
+    public Long memberId_03;
+    public Long groupId_01;
+    public Long groupId_02;
+
+    @BeforeEach
+    void setup() {
+        Member member01 = new Member(
+                1L,
+                "3231321",
+                OauthProvider.GOOGLE,
+                "test@gmail.com",
+                "새싹개발자",
+                22,
+                null,
+                Role.USER,
+                "안녕하세요 개발자입니다.",
+                0
+        );
+
+        Member member02 = new Member(
+                2L,
+                "123321123",
+                OauthProvider.KAKAO,
+                "test@kakao.com",
+                "잔디개발자",
+                30,
+                null,
+                Role.USER,
+                "안녕하세요 백수입니다.",
+                0
+        );
+
+        Member member03 = new Member(
+                3L,
+                "1231312",
+                OauthProvider.APPLE,
+                "test@apple.com",
+                "네잎개발자",
+                20,
+                null,
+                Role.USER,
+                "안녕하세요 새내기입니다.",
+                0
+        );
+        Member saveMember01 = memberRepository.save(member01);
+        Member saveMember02 = memberRepository.save(member02);
+        Member saveMember03 = memberRepository.save(member03);
+        this.memberId_01 = saveMember01.getId();
+        this.memberId_02 = saveMember02.getId();
+        this.memberId_03 = saveMember03.getId();
+
+        GroupCreateReq groupCreateReq_01 = GroupCreateReq.builder()
+                .name("봉사별")
+                .introduction("안녕하세요 봉사별 그룹입니다. 저희는 주로 연탄봉사를 다니면서 힘든 분들에게 따듯한 손길을 건내주고 있어요")
+                .maxPeople(20)
+                .groupStatus(GroupStatus.PUBLIC)
+                .build();
+        GroupCreateReq groupCreateReq_02 = GroupCreateReq.builder()
+                .name("이음별")
+                .introduction("안녕하세요 이음별 그룹입니다. 저희는 주로 어르신들을 보살피는 봉사를 하고 있어요")
+                .maxPeople(60)
+                .groupStatus(GroupStatus.PRIVATE)
+                .build();
+        this.groupId_01 = groupService.createGroup(memberId_01, groupCreateReq_01);
+        this.groupId_02 = groupService.createGroup(memberId_01, groupCreateReq_02);
+    }
+
+    @Test
+    void 참가_성공_PUBLIC_GROUP() {
+        //given
+        GroupJoinApplyReq groupJoinApplyReq = new GroupJoinApplyReq(groupId_01, JoinType.JOIN);
+
+        //when
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq);
+
+        //then
+        List<GroupUser> all = groupUserRepository.findAll();
+        assertThat(all.size()).isEqualTo(1);
+        assertThat(all.get(0).getGroup().getGroupLeader().getId()).isEqualTo(memberId_01);
+        assertThat(all.get(0).getGroup().getName()).isEqualTo("봉사별");
+        assertThat(all.get(0).getMember().getId()).isEqualTo(memberId_02);
+    }
+
+    @Test
+    void 참가_신청_성공_PRIVATE_GROUP() {
+        //given
+        GroupJoinApplyReq groupJoinApplyReq = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+
+        //when
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq);
+
+        //then
+        List<GroupJoin> allGroupJoins = groupJoinRepository.findAll();
+        List<GroupUser> allGroupUsers = groupUserRepository.findAll();
+        assertThat(allGroupJoins.size()).isEqualTo(1);
+        assertThat(allGroupJoins.get(0).getGroup().getId()).isEqualTo(groupId_02);
+        assertThat(allGroupJoins.get(0).getGroup().getName()).isEqualTo("이음별");
+        assertThat(allGroupJoins.get(0).getMember().getId()).isEqualTo(memberId_02);
+        assertThat(allGroupUsers.size()).isEqualTo(0);
+    }
+
+    @Test
+    void 참가_취소_성공() {
+        //given
+        GroupJoinApplyReq groupJoinApplyReq_01 = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq_01);
+
+        //when
+        GroupJoinApplyReq groupJoinApplyReq_02 = new GroupJoinApplyReq(groupId_02, JoinType.CANCEL);
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq_02);
+
+        //then
+        List<GroupJoin> all = groupJoinRepository.findAll();
+        assertThat(all.size()).isEqualTo(0);
+    }
+
+    @Test
+    void 참가_신청_실패_풀방() {
+        //given
+        Group byId = groupRepository.findById(groupId_01).orElse(null);
+        byId.setMaxPeople(1);
+
+        GroupJoinApplyReq groupJoinApplyReq = new GroupJoinApplyReq(groupId_01, JoinType.JOIN);
+
+        //when, then
+        assertThrows(GeneralHandler.class, () -> groupJoinService.applyJoin(memberId_02, groupJoinApplyReq));
+    }
+
+    @Test
+    void 참가_신청_실패_중복() {
+        //given
+        GroupJoinApplyReq groupJoinApplyReq_01 = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+        GroupJoinApplyReq groupJoinApplyReq_02 = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+
+        //when
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq_01);
+
+        //then
+        assertThrows(GeneralHandler.class, () -> groupJoinService.applyJoin(memberId_02, groupJoinApplyReq_02));
+    }
+
+    @Test
+    void 참가_결정_성공() {
+        //given
+        GroupJoinApplyReq groupJoinApplyReq = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq);
+
+        List<GroupJoinRes> groupJoinList = groupJoinService.getGroupJoinList(memberId_01, groupId_02);
+        Long groupJoinId = groupJoinList.get(0).groupJoinId();
+
+        GroupJoinDecideReq groupJoinDecideReq = new GroupJoinDecideReq(groupJoinId, JoinDecide.ACCEPT);
+
+        //when
+        groupJoinService.decideJoin(memberId_01, groupJoinDecideReq);
+
+        //then
+        Optional<GroupJoin> groupJoinById = groupJoinRepository.findById(groupJoinId);
+        Optional<Group> groupById = groupRepository.findById(groupId_02);
+        Optional<GroupUser> groupUserByGroupIdAndMemberId = groupUserRepository.findByGroup_IdAndMember_Id(groupById.get().getId(), memberId_02);
+
+        assertThat(groupJoinById).isEmpty();
+        assertThat(groupById.get().getCurrentPeople()).isEqualTo(2);
+        assertThat(groupUserByGroupIdAndMemberId.get().getGroup().getName()).isEqualTo("이음별");
+        assertThat(groupUserByGroupIdAndMemberId.get().getMember().getNickname()).isEqualTo("잔디개발자");
+    }
+
+    @Test
+    void 참가_결정_실패_권한없음() {
+        GroupJoinApplyReq groupJoinApplyReq = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq);
+
+        List<GroupJoinRes> groupJoinList = groupJoinService.getGroupJoinList(memberId_01, groupId_02);
+        Long groupJoinId = groupJoinList.get(0).groupJoinId();
+
+        GroupJoinDecideReq groupJoinDecideReq = new GroupJoinDecideReq(groupJoinId, JoinDecide.ACCEPT);
+
+        //when, then
+        assertThrows(GeneralHandler.class, () -> groupJoinService.decideJoin(memberId_02, groupJoinDecideReq));
+
+    }
+
+    @Test
+    void 지원_현황_성공() {
+        //given
+        GroupJoinApplyReq groupJoinApplyReq = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+
+        //when
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq);
+        groupJoinService.applyJoin(memberId_03, groupJoinApplyReq);
+
+        //then
+        List<GroupJoinRes> groupJoinList = groupJoinService.getGroupJoinList(memberId_01, groupId_02);
+        assertThat(groupJoinList.size()).isEqualTo(2);
+    }
+
+    @Test
+    void 지원자_현황_성공() {
+        //given
+        GroupJoinApplyReq groupJoinApplyReq = new GroupJoinApplyReq(groupId_02, JoinType.JOIN);
+
+        //when
+        groupJoinService.applyJoin(memberId_02, groupJoinApplyReq);
+
+        //then
+        List<GroupJoinMyRes> myGroupJoinList = groupJoinService.getMyGroupJoinList(memberId_02);
+        assertThat(myGroupJoinList.size()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
### 구현 목록 🐞 
- 그룹 참가 요청(그룹의 상태에 따라 [PUBLIC, PRIVATE] 다르게 동작)
- 그룹 참가 요청 수락/거절
- 그룹 참가 요청 리스트 조회
- 테스트 코드
- 누락된 QuerydslConfig 파일 업로드

### 이슈 사항 ❓ 
- 그룹 참가 요청 리스트 조회의 경우도 Response가 자세히 정해지지 않아 추후에 수정 예정