### PR TITLE
Member-crud 추가 구현 및 수정

### DIFF
--- a/src/main/java/com/simbongsa/global/common/constant/MemberStatus.java
+++ b/src/main/java/com/simbongsa/global/common/constant/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.simbongsa.global.common.constant;
+
+public enum MemberStatus {
+    PUBLIC, PRIVATE
+}

--- a/src/main/java/com/simbongsa/member/entity/Member.java
+++ b/src/main/java/com/simbongsa/member/entity/Member.java
@@ -52,7 +52,6 @@ public class Member extends BaseEntity {
         this.role = Role.GUEST;
     }
 
-    @Builder
     public Member(String socialId, OauthProvider oauthProvider, String email, String nickname, int age,
                   String profileImg, Role role, String introduction, int volunteerParticipationCnt, MemberStatus memberStatus) {
         this.socialId = socialId;

--- a/src/main/java/com/simbongsa/member/entity/Member.java
+++ b/src/main/java/com/simbongsa/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.simbongsa.member.entity;
 
+import com.simbongsa.global.common.constant.MemberStatus;
 import com.simbongsa.global.common.entity.BaseEntity;
 import com.simbongsa.global.common.constant.OauthProvider;
 import com.simbongsa.global.common.constant.Role;
@@ -41,11 +42,28 @@ public class Member extends BaseEntity {
 
     private Integer volunteerParticipationCnt;
 
+    private MemberStatus memberStatus;
+
     public Member(OauthMember request) {
         this.socialId = request.getSocialId();
         this.oauthProvider = request.getOauthProvider();
         this.email = request.getEmail();
         this.nickname = request.getNickname();
         this.role = Role.GUEST;
+    }
+
+    @Builder
+    public Member(String socialId, OauthProvider oauthProvider, String email, String nickname, int age,
+                  String profileImg, Role role, String introduction, int volunteerParticipationCnt, MemberStatus memberStatus) {
+        this.socialId = socialId;
+        this.oauthProvider = oauthProvider;
+        this.email = email;
+        this.nickname = nickname;
+        this.age = age;
+        this.profileImg = profileImg;
+        this.role = role;
+        this.introduction = introduction;
+        this.volunteerParticipationCnt = volunteerParticipationCnt;
+        this.memberStatus = memberStatus;
     }
 }

--- a/src/test/java/com/simbongsa/group/service/GroupServiceTest.java
+++ b/src/test/java/com/simbongsa/group/service/GroupServiceTest.java
@@ -2,6 +2,7 @@ package com.simbongsa.group.service;
 
 import com.simbongsa.global.EntityFacade;
 import com.simbongsa.global.common.constant.GroupStatus;
+import com.simbongsa.global.common.constant.MemberStatus;
 import com.simbongsa.global.common.constant.OauthProvider;
 import com.simbongsa.global.common.constant.Role;
 import com.simbongsa.global.common.exception.GeneralHandler;
@@ -48,7 +49,8 @@ class GroupServiceTest {
                 null,
                 Role.USER,
                 "안녕하세요 개발자입니다.",
-                0
+                0,
+                MemberStatus.PUBLIC
         );
         Member saveMember = memberRepository.save(member);
         this.memberId = saveMember.getId();

--- a/src/test/java/com/simbongsa/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/simbongsa/member/service/MemberServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.simbongsa.member.service;
 
 import com.simbongsa.global.EntityFacade;
+import com.simbongsa.global.common.constant.MemberStatus;
 import com.simbongsa.global.common.constant.OauthProvider;
 import com.simbongsa.global.common.constant.Role;
 import com.simbongsa.global.common.exception.GeneralHandler;
@@ -31,9 +32,8 @@ class MemberServiceImplTest {
     @Autowired
     private RedisUtil redisUtil;
 
-    Member createMember(Long id) {
+    Member createMember() {
         Member member = new Member(
-                id,
                 "3231321",
                 OauthProvider.GOOGLE,
                 "test@gmail.com",
@@ -42,7 +42,8 @@ class MemberServiceImplTest {
                 null,
                 Role.USER,
                 "안녕하세요 개발자입니다.",
-                0
+                0,
+                MemberStatus.PUBLIC
         );
         return member;
     }
@@ -50,27 +51,27 @@ class MemberServiceImplTest {
     @Test
     void deleteMember() {
         //given
-        Member member = createMember(1L);
-        memberRepository.save(member);
+        Member member = createMember();
+        Member saveMember = memberRepository.save(member);
 
         //when
-        memberService.deleteMember(1L);
+        memberService.deleteMember(saveMember.getId());
 
         //then
-        assertThrows(GeneralHandler.class, () -> entityFacade.getMember(1L));
+        assertThrows(GeneralHandler.class, () -> entityFacade.getMember(saveMember.getId()));
     }
 
     @Test
     void 로그아웃_성공() {
         //given
-        Member member = createMember(1L);
-        memberRepository.save(member);
+        Member member = createMember();
+        Member saveMember = memberRepository.save(member);
 
-        String accessToken = tokenProvider.issueAccessToken(1L);
-        String refreshToken = tokenProvider.issueRefreshToken(1L);
+        String accessToken = tokenProvider.issueAccessToken(saveMember.getId());
+        String refreshToken = tokenProvider.issueRefreshToken(saveMember.getId());
 
         //when
-        memberService.logout(accessToken, refreshToken, 1L);
+        memberService.logout(accessToken, refreshToken, saveMember.getId());
 
         //then
         assertThat(redisUtil.getData(refreshToken)).isNull();
@@ -80,14 +81,14 @@ class MemberServiceImplTest {
     @Test
     void 블랙리스트_검증_성공() {
         //given
-        Member member = createMember(1L);
-        memberRepository.save(member);
+        Member member = createMember();
+        Member saveMember = memberRepository.save(member);
 
-        String accessToken = tokenProvider.issueAccessToken(1L);
-        String refreshToken = tokenProvider.issueRefreshToken(1L);
+        String accessToken = tokenProvider.issueAccessToken(saveMember.getId());
+        String refreshToken = tokenProvider.issueRefreshToken(saveMember.getId());
 
         //when
-        memberService.logout(accessToken, refreshToken, 1L);
+        memberService.logout(accessToken, refreshToken, saveMember.getId());
 
         //then
         assertThat(redisUtil.getData(refreshToken)).isNull();


### PR DESCRIPTION
### 수정 부분
- Member entity에 유저 상태(PUBLIC, PRIVATE) 컬럼 추가
   - 컬럼 수정으로 인한 @AllArgsConstructor 범위 변경 -> 기존에 사용한 Member 생성자 수정
- MemberServiceTest에서 클래스 단위 테스트 시 테스트 실패하는 테스트 메소드 수정
