### PR TITLE
follows 기능 구현 1

### DIFF
--- a/src/main/java/com/simbongsa/follows/controller/FollowsController.java
+++ b/src/main/java/com/simbongsa/follows/controller/FollowsController.java
@@ -1,0 +1,41 @@
+package com.simbongsa.follows.controller;
+
+import com.simbongsa.follows.service.FollowsService;
+import com.simbongsa.global.common.apiPayload.CustomApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/follows")
+public class FollowsController {
+    private final FollowsService followsService;
+
+    /**
+     * 내가 팔로우하고 있는 데이터를 삭제
+     * @param loginId
+     * @param myFollowsId
+     * @return
+     */
+    @DeleteMapping("/{myFollowsId}")
+    public CustomApiResponse deleteMyFollows(@AuthenticationPrincipal Long loginId,
+                                             @PathVariable Long myFollowsId) {
+        followsService.deleteMyFollows(loginId, myFollowsId);
+        return CustomApiResponse.onSuccess();
+    }
+
+    /**
+     * 나를 팔로우하는 상대방의 데이터를 삭제
+     * @param loginId
+     * @param oppositeFollowsId
+     * @return
+     */
+    @DeleteMapping("/{oppositeFollowsId}")
+    public CustomApiResponse deleteOppositeFollows(@AuthenticationPrincipal Long loginId,
+                                                   @PathVariable Long oppositeFollowsId) {
+        followsService.deleteOppositeFollows(loginId, oppositeFollowsId);
+        return CustomApiResponse.onSuccess();
+    }
+
+}

--- a/src/main/java/com/simbongsa/follows/controller/FollowsController.java
+++ b/src/main/java/com/simbongsa/follows/controller/FollowsController.java
@@ -5,6 +5,7 @@ import com.simbongsa.follows.service.FollowsService;
 import com.simbongsa.global.common.apiPayload.CustomApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,7 +49,7 @@ public class FollowsController {
     @GetMapping("/following")
     public CustomApiResponse getMyFollowing(@AuthenticationPrincipal Long loginId,
                                             @RequestParam Long lastFollowsId,
-                                            Pageable pageable) {
+                                            @PageableDefault Pageable pageable) {
         FollowsPageRes followingPageRes = followsService.getMyFollowingPage(loginId, lastFollowsId, pageable);
         return CustomApiResponse.onSuccess(followingPageRes);
     }
@@ -63,7 +64,7 @@ public class FollowsController {
     public CustomApiResponse getMemberFollowing(@AuthenticationPrincipal Long loginId,
                                               @PathVariable Long memberId,
                                               @RequestParam Long lastFollowsId,
-                                              Pageable pageable) {
+                                              @PageableDefault Pageable pageable) {
         FollowsPageRes followingPageRes = followsService.getMemberFollowingPage(loginId, memberId, lastFollowsId, pageable);
         return CustomApiResponse.onSuccess(followingPageRes);
     }
@@ -76,7 +77,7 @@ public class FollowsController {
     @GetMapping("/follower")
     public CustomApiResponse getMyFollower(@AuthenticationPrincipal Long loginId,
                                            @RequestParam Long lastFollowsId,
-                                           Pageable pageable) {
+                                           @PageableDefault Pageable pageable) {
         FollowsPageRes followerPageRes = followsService.getMyFollowerPage(loginId, lastFollowsId, pageable);
         return CustomApiResponse.onSuccess(followerPageRes);
     }
@@ -91,7 +92,7 @@ public class FollowsController {
     public CustomApiResponse getMemberFollower(@AuthenticationPrincipal Long loginId,
                                                @PathVariable Long memberId,
                                                @RequestParam Long lastFollowsId,
-                                               Pageable pageable) {
+                                               @PageableDefault Pageable pageable) {
         FollowsPageRes followerPageRes = followsService.getMemberFollowerPage(loginId, memberId,lastFollowsId, pageable);
         return CustomApiResponse.onSuccess(followerPageRes);
     }

--- a/src/main/java/com/simbongsa/follows/controller/FollowsController.java
+++ b/src/main/java/com/simbongsa/follows/controller/FollowsController.java
@@ -1,8 +1,10 @@
 package com.simbongsa.follows.controller;
 
+import com.simbongsa.follows.dto.res.FollowsPageRes;
 import com.simbongsa.follows.service.FollowsService;
 import com.simbongsa.global.common.apiPayload.CustomApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,6 +38,62 @@ public class FollowsController {
                                                    @PathVariable Long oppositeFollowsId) {
         followsService.deleteOppositeFollows(loginId, oppositeFollowsId);
         return CustomApiResponse.onSuccess();
+    }
+
+    /**
+     * 나의 팔로잉 리스트 조회
+     * @param loginId 로그인 유저
+     * @return 팔로잉 리스트
+     */
+    @GetMapping("/following")
+    public CustomApiResponse getMyFollowing(@AuthenticationPrincipal Long loginId,
+                                            @RequestParam Long lastFollowsId,
+                                            Pageable pageable) {
+        FollowsPageRes followingPageRes = followsService.getMyFollowingPage(loginId, lastFollowsId, pageable);
+        return CustomApiResponse.onSuccess(followingPageRes);
+    }
+
+    /**
+     * 타 유저의 팔로잉 리스트 조회
+     * @param loginId  로그인 유저
+     * @param memberId 조회하려는 유저
+     * @return 타 사용자의 팔로잉 리스트
+     */
+    @GetMapping("/following/members/{memberId}")
+    public CustomApiResponse getMemberFollowing(@AuthenticationPrincipal Long loginId,
+                                              @PathVariable Long memberId,
+                                              @RequestParam Long lastFollowsId,
+                                              Pageable pageable) {
+        FollowsPageRes followingPageRes = followsService.getMemberFollowingPage(loginId, memberId, lastFollowsId, pageable);
+        return CustomApiResponse.onSuccess(followingPageRes);
+    }
+
+    /**
+     * 나의 팔로워 리스트 조회
+     * @param loginId 로그인 유저
+     * @return 팔로워 리스트
+     */
+    @GetMapping("/follower")
+    public CustomApiResponse getMyFollower(@AuthenticationPrincipal Long loginId,
+                                           @RequestParam Long lastFollowsId,
+                                           Pageable pageable) {
+        FollowsPageRes followerPageRes = followsService.getMyFollowerPage(loginId, lastFollowsId, pageable);
+        return CustomApiResponse.onSuccess(followerPageRes);
+    }
+
+    /**
+     * 타 유저의 팔로워 리스트 조회
+     * @param loginId 로그인 유저
+     * @param memberId 조회하려는 유저
+     * @return 팔로워 리스트
+     */
+    @GetMapping("/follower/member/{memberId}")
+    public CustomApiResponse getMemberFollower(@AuthenticationPrincipal Long loginId,
+                                               @PathVariable Long memberId,
+                                               @RequestParam Long lastFollowsId,
+                                               Pageable pageable) {
+        FollowsPageRes followerPageRes = followsService.getMemberFollowerPage(loginId, memberId,lastFollowsId, pageable);
+        return CustomApiResponse.onSuccess(followerPageRes);
     }
 
 }

--- a/src/main/java/com/simbongsa/follows/dto/res/FollowsPageRes.java
+++ b/src/main/java/com/simbongsa/follows/dto/res/FollowsPageRes.java
@@ -1,0 +1,42 @@
+package com.simbongsa.follows.dto.res;
+
+import com.simbongsa.follows.entity.Follows;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record FollowsPageRes(
+        List<FollowsRes> followsResList,
+        Long lastFollowsRequestId,
+        Boolean hasNext
+) {
+    public static FollowsPageRes mapFollowingPageToPageRes(Slice<Follows> myFollowingPage) {
+        return FollowsPageRes.builder()
+                .followsResList(
+                        myFollowingPage.stream()
+                                .map(FollowsRes::mapFollowingToFollowsRes)
+                                .toList()
+                )
+                .lastFollowsRequestId(getLastId(myFollowingPage.getContent()))
+                .hasNext(myFollowingPage.hasNext())
+                .build();
+    }
+
+    public static FollowsPageRes mapFollowerPageToPageRes(Slice<Follows> myFollowerPage) {
+        return FollowsPageRes.builder()
+                .followsResList(
+                        myFollowerPage.stream()
+                                .map(FollowsRes::mapFollowerToFollowsRes)
+                                .toList()
+                )
+                .lastFollowsRequestId(getLastId(myFollowerPage.getContent()))
+                .hasNext(myFollowerPage.hasNext())
+                .build();
+    }
+
+    private static Long getLastId(List<Follows> followsList) {
+        return followsList.isEmpty() ? null : followsList.get(followsList.size() - 1).getId();
+    }
+}

--- a/src/main/java/com/simbongsa/follows/dto/res/FollowsRes.java
+++ b/src/main/java/com/simbongsa/follows/dto/res/FollowsRes.java
@@ -1,0 +1,33 @@
+package com.simbongsa.follows.dto.res;
+
+import com.simbongsa.follows.entity.Follows;
+import com.simbongsa.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record FollowsRes(
+        Long followsId,
+        Long memberId,
+        String nickname,
+        String profileImg
+) {
+    public static FollowsRes mapFollowingToFollowsRes(Follows follows) {
+        Member followedMember = follows.getFollowedMember();
+        return FollowsRes.builder()
+                .followsId(follows.getId())
+                .memberId(followedMember.getId())
+                .nickname(followedMember.getNickname())
+                .profileImg(followedMember.getProfileImg())
+                .build();
+    }
+
+    public static FollowsRes mapFollowerToFollowsRes(Follows follows) {
+        Member getFollowingMember = follows.getFollowingMember();
+        return FollowsRes.builder()
+                .followsId(follows.getId())
+                .memberId(getFollowingMember.getId())
+                .nickname(getFollowingMember.getNickname())
+                .profileImg(getFollowingMember.getProfileImg())
+                .build();
+    }
+}

--- a/src/main/java/com/simbongsa/follows/repository/FollowsRepositoryCustom.java
+++ b/src/main/java/com/simbongsa/follows/repository/FollowsRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.simbongsa.follows.repository;
+
+import com.simbongsa.follows.entity.Follows;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface FollowsRepositoryCustom {
+    Slice<Follows> getFollowingPage(Long loginId, Long lastFollowsId, Pageable pageable);
+    Slice<Follows> getFollowerPage(Long loginId, Long lastFollowsId, Pageable pageable);
+}

--- a/src/main/java/com/simbongsa/follows/repository/FollowsRepositoryCustomImpl.java
+++ b/src/main/java/com/simbongsa/follows/repository/FollowsRepositoryCustomImpl.java
@@ -1,0 +1,82 @@
+package com.simbongsa.follows.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.simbongsa.follows.entity.Follows;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.simbongsa.follows.entity.QFollows.follows;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class FollowsRepositoryCustomImpl implements FollowsRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Follows> getFollowingPage(Long memberId, Long lastFollowsId, Pageable pageable) {
+        List<Follows> followingList = getFollowingList(memberId, lastFollowsId, pageable);
+        boolean hasNext = hasNextPage(followingList, pageable);
+        return new SliceImpl<>(followingList, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<Follows> getFollowerPage(Long memberId, Long lastFollowsId, Pageable pageable) {
+        List<Follows> followingList = getFollowerList(memberId, lastFollowsId, pageable);
+        boolean hasNext = hasNextPage(followingList, pageable);
+        return new SliceImpl<>(followingList, pageable, hasNext);
+    }
+
+    private List<Follows> getFollowerList(Long memberId, Long lastFollowsId, Pageable pageable) {
+        return queryFactory
+                .selectFrom(follows)
+                .where(
+                        ltFollowsId(lastFollowsId),
+                        eqFollowedMemberId(memberId)
+                )
+                .orderBy(follows.createdAt.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private BooleanExpression eqFollowedMemberId(Long memberId) {
+        return follows.followedMember.id.eq(memberId);
+    }
+
+    private List<Follows> getFollowingList(Long memberId, Long lastFollowsId, Pageable pageable) {
+        return queryFactory
+                .selectFrom(follows)
+                .where(
+                        ltFollowsId(lastFollowsId),
+                        eqFollowingMemberId(memberId)
+                )
+                .orderBy(follows.createdAt.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private BooleanExpression eqFollowingMemberId(Long memberId) {
+        return follows.followingMember.id.eq(memberId);
+    }
+
+    private BooleanExpression ltFollowsId(Long followsId) {
+        if (followsId == null) return null;
+        return follows.id.lt(followsId);
+    }
+
+    private Boolean hasNextPage(List<Follows> followsList, Pageable pageable) {
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+        if (followsList.size() > pageable.getPageSize()) {
+            followsList.remove(pageable.getPageSize());
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/simbongsa/follows/service/FollowsService.java
+++ b/src/main/java/com/simbongsa/follows/service/FollowsService.java
@@ -1,7 +1,18 @@
 package com.simbongsa.follows.service;
 
+import com.simbongsa.follows.dto.res.FollowsPageRes;
+import org.springframework.data.domain.Pageable;
+
 public interface FollowsService {
     void deleteMyFollows(Long loginId, Long followsId);
 
     void deleteOppositeFollows(Long loginId, Long followsId);
+
+    FollowsPageRes getMyFollowingPage(Long loginId, Long lastFollowsId, Pageable pageable);
+
+    FollowsPageRes getMemberFollowingPage(Long loginId, Long memberId, Long lastFollowsId, Pageable pageable);
+
+    FollowsPageRes getMyFollowerPage(Long loginId, Long lastFollowsId, Pageable pageable);
+
+    FollowsPageRes getMemberFollowerPage(Long loginId, Long memberId, Long lastFollowsId, Pageable pageable);
 }

--- a/src/main/java/com/simbongsa/follows/service/FollowsService.java
+++ b/src/main/java/com/simbongsa/follows/service/FollowsService.java
@@ -1,0 +1,7 @@
+package com.simbongsa.follows.service;
+
+public interface FollowsService {
+    void deleteMyFollows(Long loginId, Long followsId);
+
+    void deleteOppositeFollows(Long loginId, Long followsId);
+}

--- a/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
+++ b/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
@@ -31,7 +31,7 @@ public class FollowsServiceImpl implements FollowsService {
     public void deleteMyFollows(Long loginId, Long followsId) {
         Follows follows = entityFacade.getFollows(followsId);
 
-        if (!validateMyFollowsTarget(loginId, follows.getFollowingMember().getId())) {
+        if (!validateFollowsTarget(loginId, follows.getFollowingMember().getId())) {
             throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
         }
 
@@ -42,7 +42,7 @@ public class FollowsServiceImpl implements FollowsService {
     public void deleteOppositeFollows(Long loginId, Long followsId) {
         Follows follows = entityFacade.getFollows(followsId);
 
-        if (!validateOppositeFollowsTarget(loginId, follows.getFollowedMember().getId())) {
+        if (!validateFollowsTarget(loginId, follows.getFollowedMember().getId())) {
             throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
         }
 
@@ -95,11 +95,8 @@ public class FollowsServiceImpl implements FollowsService {
         }
     }
 
-    private boolean validateOppositeFollowsTarget(Long loginId, Long followedId) {
+    private boolean validateFollowsTarget(Long loginId, Long followedId) {
         return followedId.equals(loginId);
     }
 
-    private boolean validateMyFollowsTarget(Long loginId, Long followingId) {
-        return followingId.equals(loginId);
-    }
 }

--- a/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
+++ b/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
@@ -30,22 +30,14 @@ public class FollowsServiceImpl implements FollowsService {
     @Override
     public void deleteMyFollows(Long loginId, Long followsId) {
         Follows follows = entityFacade.getFollows(followsId);
-
-        if (!validateFollowsTarget(loginId, follows.getFollowingMember().getId())) {
-            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
-        }
-
+        validateFollowsTarget(loginId, follows.getFollowingMember().getId());
         followsRepository.delete(follows);
     }
 
     @Override
     public void deleteOppositeFollows(Long loginId, Long followsId) {
         Follows follows = entityFacade.getFollows(followsId);
-
-        if (!validateFollowsTarget(loginId, follows.getFollowedMember().getId())) {
-            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
-        }
-
+        validateFollowsTarget(loginId, follows.getFollowedMember().getId());
         followsRepository.delete(follows);
     }
 
@@ -95,8 +87,10 @@ public class FollowsServiceImpl implements FollowsService {
         }
     }
 
-    private boolean validateFollowsTarget(Long loginId, Long followedId) {
-        return followedId.equals(loginId);
+    private void validateFollowsTarget(Long loginId, Long targetId) {
+        if (!loginId.equals(targetId)) {
+            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
+        }
     }
 
 }

--- a/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
+++ b/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
@@ -1,14 +1,22 @@
 package com.simbongsa.follows.service;
 
+import com.simbongsa.follows.dto.res.FollowsPageRes;
 import com.simbongsa.follows.entity.Follows;
 import com.simbongsa.follows.repository.FollowsRepository;
+import com.simbongsa.follows.repository.FollowsRepositoryCustom;
 import com.simbongsa.global.EntityFacade;
 import com.simbongsa.global.common.apiPayload.code.statusEnums.ErrorStatus;
+import com.simbongsa.global.common.constant.MemberStatus;
 import com.simbongsa.global.common.exception.GeneralHandler;
+import com.simbongsa.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Transactional
@@ -16,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class FollowsServiceImpl implements FollowsService {
     private final FollowsRepository followsRepository;
+    private final FollowsRepositoryCustom followsRepositoryCustom;
     private final EntityFacade entityFacade;
 
     @Override
@@ -38,6 +47,52 @@ public class FollowsServiceImpl implements FollowsService {
         }
 
         followsRepository.delete(follows);
+    }
+
+    @Override
+    public FollowsPageRes getMyFollowingPage(Long loginId, Long lastFollowsId, Pageable pageable) {
+        Slice<Follows> myFollowingPage = followsRepositoryCustom.getFollowingPage(loginId, lastFollowsId, pageable);
+        return FollowsPageRes.mapFollowingPageToPageRes(myFollowingPage);
+    }
+
+    @Override
+    public FollowsPageRes getMemberFollowingPage(Long loginId, Long memberId, Long lastFollowsId, Pageable pageable) {
+        // member의 상태가 PRIVATE일 경우 login->member를 팔로우하고 있어야 조회 가능
+        Member targetMember = entityFacade.getMember(memberId);
+
+        if (targetMember.getMemberStatus() == MemberStatus.PRIVATE) {
+            verifyFollowingRelationship(loginId, targetMember);
+        }
+
+        Slice<Follows> memberFollowingPage = followsRepositoryCustom.getFollowingPage(memberId, lastFollowsId, pageable);
+        return FollowsPageRes.mapFollowingPageToPageRes(memberFollowingPage);
+    }
+
+    @Override
+    public FollowsPageRes getMyFollowerPage(Long loginId, Long lastFollowsId, Pageable pageable) {
+        Slice<Follows> myFollowerPage = followsRepositoryCustom.getFollowerPage(loginId, lastFollowsId, pageable);
+        return FollowsPageRes.mapFollowerPageToPageRes(myFollowerPage);
+    }
+
+    @Override
+    public FollowsPageRes getMemberFollowerPage(Long loginId, Long memberId, Long lastFollowsId, Pageable pageable) {
+        // member의 상태가 PRIVATE일 경우 login->member를 팔로우하고 있어야 조회 가능
+        Member targetMember = entityFacade.getMember(memberId);
+
+        if (targetMember.getMemberStatus() == MemberStatus.PRIVATE) {
+            verifyFollowingRelationship(loginId, targetMember);
+        }
+
+        Slice<Follows> memberFollowerPage = followsRepositoryCustom.getFollowerPage(memberId, lastFollowsId, pageable);
+        return FollowsPageRes.mapFollowerPageToPageRes(memberFollowerPage);
+    }
+
+    private void verifyFollowingRelationship(Long loginId, Member targetMember) {
+        Member loginMember = entityFacade.getMember(loginId);
+        Optional<Follows> optionalFollows = entityFacade.getFollowsByFollowingMemberAndFollowedMember(loginMember, targetMember);
+        if (!optionalFollows.isPresent()) {
+            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
+        }
     }
 
     private boolean validateOppositeFollowsTarget(Long loginId, Long followedId) {

--- a/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
+++ b/src/main/java/com/simbongsa/follows/service/FollowsServiceImpl.java
@@ -1,0 +1,50 @@
+package com.simbongsa.follows.service;
+
+import com.simbongsa.follows.entity.Follows;
+import com.simbongsa.follows.repository.FollowsRepository;
+import com.simbongsa.global.EntityFacade;
+import com.simbongsa.global.common.apiPayload.code.statusEnums.ErrorStatus;
+import com.simbongsa.global.common.exception.GeneralHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class FollowsServiceImpl implements FollowsService {
+    private final FollowsRepository followsRepository;
+    private final EntityFacade entityFacade;
+
+    @Override
+    public void deleteMyFollows(Long loginId, Long followsId) {
+        Follows follows = entityFacade.getFollows(followsId);
+
+        if (!validateMyFollowsTarget(loginId, follows.getFollowingMember().getId())) {
+            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
+        }
+
+        followsRepository.delete(follows);
+    }
+
+    @Override
+    public void deleteOppositeFollows(Long loginId, Long followsId) {
+        Follows follows = entityFacade.getFollows(followsId);
+
+        if (!validateOppositeFollowsTarget(loginId, follows.getFollowedMember().getId())) {
+            throw new GeneralHandler(ErrorStatus.USER_FORBIDDEN);
+        }
+
+        followsRepository.delete(follows);
+    }
+
+    private boolean validateOppositeFollowsTarget(Long loginId, Long followedId) {
+        return followedId.equals(loginId);
+    }
+
+    private boolean validateMyFollowsTarget(Long loginId, Long followingId) {
+        return followingId.equals(loginId);
+    }
+}

--- a/src/main/java/com/simbongsa/global/EntityFacade.java
+++ b/src/main/java/com/simbongsa/global/EntityFacade.java
@@ -82,6 +82,11 @@ public class EntityFacade {
                 () -> new GeneralHandler(ErrorStatus.FOLLOWS_REQUESTS_NOT_FOUND));
     }
 
+    public Follows getFollows(Long followsId) {
+        return followsRepository.findById(followsId).orElseThrow(
+                () -> new GeneralHandler(ErrorStatus.FOLLOWS_NOT_FOUND)
+        );
+    }
     public Optional<Follows> getFollowsByFollowingMemberAndFollowedMember(Member followingMember, Member followedMember) {
         return followsRepository.findByFollowingMemberAndFollowedMember(followingMember, followedMember);
     }

--- a/src/main/java/com/simbongsa/global/common/apiPayload/code/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/simbongsa/global/common/apiPayload/code/statusEnums/ErrorStatus.java
@@ -44,6 +44,7 @@ public enum ErrorStatus implements BaseCode {
 
     // 팔로우 관련
     DUPLICATED_FOLLOWS(HttpStatus.BAD_REQUEST, "FOLLOWS400", "이미 존재하는 팔로우입니다."),
+    FOLLOWS_NOT_FOUND(HttpStatus.BAD_REQUEST, "FOLLOWS404", "팔로우를 찾을 수 없습니다"),
 
     // 팔로우 요청 관련
     FOLLOWS_REQUESTS_NOT_FOUND(HttpStatus.BAD_REQUEST, "FOLLOWS_REQUESTS4001", "존재하지 않는 팔로우 요청입니다"),

--- a/src/test/java/com/simbongsa/follows/service/FollowsServiceImplTest.java
+++ b/src/test/java/com/simbongsa/follows/service/FollowsServiceImplTest.java
@@ -1,0 +1,132 @@
+package com.simbongsa.follows.service;
+
+import com.simbongsa.follows.entity.Follows;
+import com.simbongsa.follows.repository.FollowsRepository;
+import com.simbongsa.follows_requests.service.FollowsRequestsService;
+import com.simbongsa.global.common.constant.MemberStatus;
+import com.simbongsa.global.common.constant.OauthProvider;
+import com.simbongsa.global.common.constant.Role;
+import com.simbongsa.global.common.exception.GeneralHandler;
+import com.simbongsa.member.entity.Member;
+import com.simbongsa.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class FollowsServiceImplTest {
+
+    private static final Logger log = LoggerFactory.getLogger(FollowsServiceImplTest.class);
+    @Autowired
+    private FollowsService followsService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private FollowsRequestsService followsRequestsService;
+    @Autowired
+    private FollowsRepository followsRepository;
+
+    Long saveMember(String socialId, MemberStatus memberStatus) {
+        Member saveMember = memberRepository.save(new Member(
+                socialId,
+                OauthProvider.GOOGLE,
+                "test@gmail.com",
+                "test",
+                20,
+                null,
+                Role.USER,
+                "안녕하세요 개발자입니다.",
+                0,
+                memberStatus
+        ));
+        return saveMember.getId();
+    }
+
+    Long saveMember(String nickname, String socialId, MemberStatus memberStatus) {
+        Member saveMember = memberRepository.save(new Member(
+                socialId,
+                OauthProvider.GOOGLE,
+                "test@gmail.com",
+                nickname,
+                20,
+                null,
+                Role.USER,
+                "안녕하세요 개발자입니다.",
+                0,
+                memberStatus
+        ));
+        return saveMember.getId();
+    }
+
+    @Test
+    void 내가_신청한_팔로우_삭제_성공() {
+        //given
+        Long followingMemberId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test2", MemberStatus.PUBLIC);
+        followsRequestsService.follow(followingMemberId, followedMemberId);
+
+        List<Follows> all = followsRepository.findAll();
+        Follows follows = all.get(0);
+
+        //when
+        followsService.deleteMyFollows(followingMemberId, follows.getId());
+
+        //then
+        assertThat(followsRepository.findAll()).hasSize(0);
+    }
+
+    @Test
+    void 내가_신청한_팔로우_삭제_실패() {
+        //given
+        Long followingMemberId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test2", MemberStatus.PUBLIC);
+        followsRequestsService.follow(followingMemberId, followedMemberId);
+
+        List<Follows> all = followsRepository.findAll();
+        Follows follows = all.get(0);
+
+        //when - then
+        assertThrows(GeneralHandler.class, () -> followsService.deleteMyFollows(followedMemberId, follows.getId()));
+    }
+
+    @Test
+    void 상대방_팔로우_삭제_성공() {
+        //given
+        Long followingMemberId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test2", MemberStatus.PUBLIC);
+        followsRequestsService.follow(followingMemberId, followedMemberId);
+
+        List<Follows> all = followsRepository.findAll();
+        Follows follows = all.get(0);
+
+        //when
+        followsService.deleteOppositeFollows(followedMemberId, follows.getId());
+
+        //then
+        assertThat(followsRepository.findAll()).hasSize(0);
+    }
+
+    @Test
+    void 상대방_팔로우_삭제_실패() {
+        //given
+        Long followingMemberId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test2", MemberStatus.PUBLIC);
+        followsRequestsService.follow(followingMemberId, followedMemberId);
+
+        List<Follows> all = followsRepository.findAll();
+        Follows follows = all.get(0);
+
+        //when - then
+        assertThrows(GeneralHandler.class, () -> followsService.deleteOppositeFollows(followingMemberId, follows.getId()));
+    }
+
+}

--- a/src/test/java/com/simbongsa/follows/service/FollowsServiceImplTest.java
+++ b/src/test/java/com/simbongsa/follows/service/FollowsServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.simbongsa.follows.service;
 
+import com.simbongsa.follows.dto.res.FollowsPageRes;
 import com.simbongsa.follows.entity.Follows;
 import com.simbongsa.follows.repository.FollowsRepository;
 import com.simbongsa.follows_requests.service.FollowsRequestsService;
@@ -15,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -41,22 +43,6 @@ class FollowsServiceImplTest {
                 OauthProvider.GOOGLE,
                 "test@gmail.com",
                 "test",
-                20,
-                null,
-                Role.USER,
-                "안녕하세요 개발자입니다.",
-                0,
-                memberStatus
-        ));
-        return saveMember.getId();
-    }
-
-    Long saveMember(String nickname, String socialId, MemberStatus memberStatus) {
-        Member saveMember = memberRepository.save(new Member(
-                socialId,
-                OauthProvider.GOOGLE,
-                "test@gmail.com",
-                nickname,
                 20,
                 null,
                 Role.USER,
@@ -129,4 +115,214 @@ class FollowsServiceImplTest {
         assertThrows(GeneralHandler.class, () -> followsService.deleteOppositeFollows(followingMemberId, follows.getId()));
     }
 
+    @Test
+    void 나의_팔로잉_조회(){
+        //given
+        Long followingMemberId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followedMemberId_01 = saveMember("test2", MemberStatus.PUBLIC);
+        Long followedMemberId_02 = saveMember("test3", MemberStatus.PUBLIC);
+
+        followsRequestsService.follow(followingMemberId, followedMemberId_01);
+        followsRequestsService.follow(followingMemberId, followedMemberId_02);
+
+        //when
+        FollowsPageRes myFollowsPage_01 = followsService.getMyFollowingPage(
+                followingMemberId,
+                null,
+                PageRequest.of(0, 1)
+        );
+        FollowsPageRes myFollowsPage_02 = followsService.getMyFollowingPage(
+                followingMemberId,
+                myFollowsPage_01.lastFollowsRequestId(),
+                PageRequest.of(1, 1)
+        );
+
+        //then
+        assertThat(myFollowsPage_01.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_01.followsResList().get(0).memberId()).isEqualTo(followedMemberId_02);
+        assertThat(myFollowsPage_01.hasNext()).isTrue();
+        assertThat(myFollowsPage_02.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_02.followsResList().get(0).memberId()).isEqualTo(followedMemberId_01);
+        assertThat(myFollowsPage_02.hasNext()).isFalse();
+    }
+
+    @Test
+    void 타유저의_팔로잉_조회_성공(){
+        //given
+        Long loginId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followingMemberId = saveMember("test2", MemberStatus.PUBLIC);
+        Long followedMemberId_01 = saveMember("test3", MemberStatus.PUBLIC);
+        Long followedMemberId_02 = saveMember("test4", MemberStatus.PUBLIC);
+
+        followsRequestsService.follow(loginId, followingMemberId);
+        followsRequestsService.follow(followingMemberId, followedMemberId_01);
+        followsRequestsService.follow(followingMemberId, followedMemberId_02);
+
+        Member followingMember = memberRepository.findById(followingMemberId).get();
+        followingMember.setMemberStatus(MemberStatus.PRIVATE);
+        memberRepository.save(followingMember);
+
+        //when
+        FollowsPageRes memberFollowsPage_01 = followsService.getMemberFollowingPage(
+                loginId,
+                followingMemberId,
+                null,
+                PageRequest.of(0, 1)
+        );
+        FollowsPageRes memberFollowsPage_02 = followsService.getMemberFollowingPage(
+                loginId,
+                followingMemberId,
+                memberFollowsPage_01.lastFollowsRequestId(),
+                PageRequest.of(1, 1)
+        );
+
+        //then
+        assertThat(memberFollowsPage_01.followsResList().size()).isEqualTo(1);
+        assertThat(memberFollowsPage_01.followsResList().get(0).memberId()).isEqualTo(followedMemberId_02);
+        assertThat(memberFollowsPage_01.hasNext()).isTrue();
+        assertThat(memberFollowsPage_02.followsResList().size()).isEqualTo(1);
+        assertThat(memberFollowsPage_02.followsResList().get(0).memberId()).isEqualTo(followedMemberId_01);
+        assertThat(memberFollowsPage_02.hasNext()).isFalse();
+    }
+
+    @Test
+    void 타유저의_팔로잉_조회_실패(){
+        //given
+        Long loginId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followingMemberId = saveMember("test2", MemberStatus.PRIVATE);
+        Long followedMemberId_01 = saveMember("test3", MemberStatus.PUBLIC);
+        Long followedMemberId_02 = saveMember("test4", MemberStatus.PUBLIC);
+
+        followsRequestsService.follow(followingMemberId, followedMemberId_01);
+        followsRequestsService.follow(followingMemberId, followedMemberId_02);
+
+        // when-then
+        assertThrows(GeneralHandler.class, () -> followsService.getMemberFollowingPage(
+                loginId,
+                followingMemberId,
+                null,
+                PageRequest.of(0, 1)
+        ));
+    }
+
+    @Test
+    void 나의_팔로워_조회(){
+        //given
+        Long followingMemberId_01 = saveMember("test1", MemberStatus.PUBLIC);
+        Long followingMemberId_02 = saveMember("test2", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test3", MemberStatus.PUBLIC);
+
+        followsRequestsService.follow(followingMemberId_01, followedMemberId);
+        followsRequestsService.follow(followingMemberId_02, followedMemberId);
+
+        //when
+        FollowsPageRes myFollowsPage_01 = followsService.getMyFollowerPage(
+                followedMemberId,
+                null,
+                PageRequest.of(0, 1)
+        );
+        FollowsPageRes myFollowsPage_02 = followsService.getMyFollowerPage(
+                followedMemberId,
+                myFollowsPage_01.lastFollowsRequestId(),
+                PageRequest.of(1, 1)
+        );
+
+        //then
+        assertThat(myFollowsPage_01.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_01.followsResList().get(0).memberId()).isEqualTo(followingMemberId_02);
+        assertThat(myFollowsPage_01.hasNext()).isTrue();
+        assertThat(myFollowsPage_02.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_02.followsResList().get(0).memberId()).isEqualTo(followingMemberId_01);
+        assertThat(myFollowsPage_02.hasNext()).isFalse();
+    }
+
+    @Test
+    void 타유저의_팔로워_조회_성공_with_public(){
+        //given
+        Long loginId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followingMemberId = saveMember("test2", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test3", MemberStatus.PUBLIC);
+
+        followsRequestsService.follow(loginId, followedMemberId);
+        followsRequestsService.follow(followingMemberId, followedMemberId);
+
+        //when
+        FollowsPageRes myFollowsPage_01 = followsService.getMemberFollowerPage(
+                loginId,
+                followedMemberId,
+                null,
+                PageRequest.of(0, 1)
+        );
+        FollowsPageRes myFollowsPage_02 = followsService.getMemberFollowerPage(
+                loginId,
+                followedMemberId,
+                myFollowsPage_01.lastFollowsRequestId(),
+                PageRequest.of(1, 1)
+        );
+
+        //then
+        assertThat(myFollowsPage_01.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_01.followsResList().get(0).memberId()).isEqualTo(followingMemberId);
+        assertThat(myFollowsPage_01.hasNext()).isTrue();
+        assertThat(myFollowsPage_02.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_02.followsResList().get(0).memberId()).isEqualTo(loginId);
+        assertThat(myFollowsPage_02.hasNext()).isFalse();
+    }
+
+    @Test
+    void 타유저의_팔로워_조회_성공_with_private(){
+        //given
+        Long loginId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followingMemberId = saveMember("test2", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test3", MemberStatus.PUBLIC);
+
+        followsRequestsService.follow(loginId, followedMemberId);
+        followsRequestsService.follow(followingMemberId, followedMemberId);
+
+        Member followedMember = memberRepository.findById(followedMemberId).get();
+        followedMember.setMemberStatus(MemberStatus.PRIVATE);
+        memberRepository.save(followedMember);
+
+        //when
+        FollowsPageRes myFollowsPage_01 = followsService.getMemberFollowerPage(
+                loginId,
+                followedMemberId,
+                null,
+                PageRequest.of(0, 1)
+        );
+        FollowsPageRes myFollowsPage_02 = followsService.getMemberFollowerPage(
+                loginId,
+                followedMemberId,
+                myFollowsPage_01.lastFollowsRequestId(),
+                PageRequest.of(1, 1)
+        );
+
+        //then
+        assertThat(myFollowsPage_01.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_01.followsResList().get(0).memberId()).isEqualTo(followingMemberId);
+        assertThat(myFollowsPage_01.hasNext()).isTrue();
+        assertThat(myFollowsPage_02.followsResList().size()).isEqualTo(1);
+        assertThat(myFollowsPage_02.followsResList().get(0).memberId()).isEqualTo(loginId);
+        assertThat(myFollowsPage_02.hasNext()).isFalse();
+    }
+
+    @Test
+    void 타유저의_팔로워_조회_실패(){
+        //given
+        Long loginId = saveMember("test1", MemberStatus.PUBLIC);
+        Long followingMemberId_01 = saveMember("test2", MemberStatus.PUBLIC);
+        Long followingMemberId_02 = saveMember("test3", MemberStatus.PUBLIC);
+        Long followedMemberId = saveMember("test4", MemberStatus.PRIVATE);
+
+        followsRequestsService.follow(followingMemberId_01, followedMemberId);
+        followsRequestsService.follow(followingMemberId_02, followedMemberId);
+
+        // when-then
+        assertThrows(GeneralHandler.class, () -> followsService.getMemberFollowerPage(
+                loginId,
+                followedMemberId,
+                null,
+                PageRequest.of(0, 1)
+        ));
+    }
 }


### PR DESCRIPTION
## 구현 목록 🐞
- [x] 내가 팔로잉하는 팔로우 삭제
- [x] 나를 팔로잉하는 팔로우 삭제
- [x] 나의 팔로잉/팔로워 리스트 조회
- [x] 타유저의 팔로잉/팔로워 리스트 조회

## 이슈 🎏 
- 모든 리스트 조회는 no-offset 방식을 사용하여 조회
- 조회하려는 유저의 상태가 PRIVATE일 경우
        -> 조회하는 유저가 조회하려는 유저를 팔로우하고 있어야지만 조회 가능하도록 구현