### PR TITLE
중복 코드 개선위한 pageUtil 구현

### DIFF
--- a/src/main/java/com/simbongsa/follows/dto/res/FollowsPageRes.java
+++ b/src/main/java/com/simbongsa/follows/dto/res/FollowsPageRes.java
@@ -1,6 +1,7 @@
 package com.simbongsa.follows.dto.res;
 
 import com.simbongsa.follows.entity.Follows;
+import com.simbongsa.global.util.PageUtil;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
@@ -19,7 +20,7 @@ public record FollowsPageRes(
                                 .map(FollowsRes::mapFollowingToFollowsRes)
                                 .toList()
                 )
-                .lastFollowsRequestId(getLastId(myFollowingPage.getContent()))
+                .lastFollowsRequestId(PageUtil.getLastElement(myFollowingPage.getContent()).getId())
                 .hasNext(myFollowingPage.hasNext())
                 .build();
     }
@@ -31,12 +32,9 @@ public record FollowsPageRes(
                                 .map(FollowsRes::mapFollowerToFollowsRes)
                                 .toList()
                 )
-                .lastFollowsRequestId(getLastId(myFollowerPage.getContent()))
+                .lastFollowsRequestId(PageUtil.getLastElement(myFollowerPage.getContent()).getId())
                 .hasNext(myFollowerPage.hasNext())
                 .build();
     }
 
-    private static Long getLastId(List<Follows> followsList) {
-        return followsList.isEmpty() ? null : followsList.get(followsList.size() - 1).getId();
-    }
 }

--- a/src/main/java/com/simbongsa/follows/repository/FollowsRepositoryCustomImpl.java
+++ b/src/main/java/com/simbongsa/follows/repository/FollowsRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.simbongsa.follows.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.simbongsa.follows.entity.Follows;
+import com.simbongsa.global.util.PageUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -23,14 +24,14 @@ public class FollowsRepositoryCustomImpl implements FollowsRepositoryCustom {
     @Override
     public Slice<Follows> getFollowingPage(Long memberId, Long lastFollowsId, Pageable pageable) {
         List<Follows> followingList = getFollowingList(memberId, lastFollowsId, pageable);
-        boolean hasNext = hasNextPage(followingList, pageable);
+        boolean hasNext = PageUtil.hasNextPage(followingList, pageable);
         return new SliceImpl<>(followingList, pageable, hasNext);
     }
 
     @Override
     public Slice<Follows> getFollowerPage(Long memberId, Long lastFollowsId, Pageable pageable) {
         List<Follows> followingList = getFollowerList(memberId, lastFollowsId, pageable);
-        boolean hasNext = hasNextPage(followingList, pageable);
+        boolean hasNext = PageUtil.hasNextPage(followingList, pageable);
         return new SliceImpl<>(followingList, pageable, hasNext);
     }
 
@@ -71,12 +72,4 @@ public class FollowsRepositoryCustomImpl implements FollowsRepositoryCustom {
         return follows.id.lt(followsId);
     }
 
-    private Boolean hasNextPage(List<Follows> followsList, Pageable pageable) {
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (followsList.size() > pageable.getPageSize()) {
-            followsList.remove(pageable.getPageSize());
-            return true;
-        }
-        return false;
-    }
 }

--- a/src/main/java/com/simbongsa/follows_requests/dto/res/FollowsRequestsPageRes.java
+++ b/src/main/java/com/simbongsa/follows_requests/dto/res/FollowsRequestsPageRes.java
@@ -1,6 +1,7 @@
 package com.simbongsa.follows_requests.dto.res;
 
 import com.simbongsa.follows_requests.entity.FollowsRequests;
+import com.simbongsa.global.util.PageUtil;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
@@ -20,7 +21,7 @@ public record FollowsRequestsPageRes(
                                 .map(FollowsRequestsRes::mapFollowedMemberToRequestsRes)
                                 .toList()
                 )
-                .lastFollowsRequestId(getLastId(slice.getContent()))
+                .lastFollowsRequestId(PageUtil.getLastElement(slice.getContent()).getId())
                 .hasNext(slice.hasNext())
                 .build();
     }
@@ -33,13 +34,9 @@ public record FollowsRequestsPageRes(
                                 .map(FollowsRequestsRes::mapFollowingMemberToRequestsRes)
                                 .toList()
                 )
-                .lastFollowsRequestId(getLastId(slice.getContent()))
+                .lastFollowsRequestId(PageUtil.getLastElement(slice.getContent()).getId())
                 .hasNext(slice.hasNext())
                 .build();
-    }
-
-    private static Long getLastId(List<FollowsRequests> followsRequestsList) {
-        return followsRequestsList.isEmpty() ? null : followsRequestsList.get(followsRequestsList.size() - 1).getId();
     }
 
 }

--- a/src/main/java/com/simbongsa/follows_requests/repository/FollowsRequestsRepositoryCustomImpl.java
+++ b/src/main/java/com/simbongsa/follows_requests/repository/FollowsRequestsRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.simbongsa.follows_requests.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.simbongsa.follows_requests.entity.FollowsRequests;
+import com.simbongsa.global.util.PageUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +24,7 @@ public class FollowsRequestsRepositoryCustomImpl implements FollowsRequestsRepos
     @Override
     public Slice<FollowsRequests> getSentFollowsRequestsPage(Long memberId, Long lastFollowsRequestsId, Pageable pageable) {
         List<FollowsRequests> followsRequestsList = getSentFollowsRequestsList(memberId, lastFollowsRequestsId, pageable);
-        Boolean hasNext = hasNextPage(followsRequestsList, pageable);
+        Boolean hasNext = PageUtil.hasNextPage(followsRequestsList, pageable);
         return new SliceImpl<>(followsRequestsList, pageable, hasNext);
     }
 
@@ -42,7 +43,7 @@ public class FollowsRequestsRepositoryCustomImpl implements FollowsRequestsRepos
     @Override
     public Slice<FollowsRequests> getReceivedFollowsRequestsPage(Long memberId, Long lastFollowsRequestsId, Pageable pageable) {
         List<FollowsRequests> followsRequestsList = getReceivedFollowsRequestsList(memberId, lastFollowsRequestsId, pageable);
-        Boolean hasNext = hasNextPage(followsRequestsList, pageable);
+        Boolean hasNext = PageUtil.hasNextPage(followsRequestsList, pageable);
         return new SliceImpl<>(followsRequestsList, pageable, hasNext);
     }
 
@@ -69,15 +70,6 @@ public class FollowsRequestsRepositoryCustomImpl implements FollowsRequestsRepos
 
     private BooleanExpression eqFollowedMemberId(Long memberId) {
         return followsRequests.followedMember.id.eq(memberId);
-    }
-
-    private Boolean hasNextPage(List<FollowsRequests> followsRequestsList, Pageable pageable) {
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (followsRequestsList.size() > pageable.getPageSize()) {
-            followsRequestsList.remove(pageable.getPageSize());
-            return true;
-        }
-        return false;
     }
 
 }

--- a/src/main/java/com/simbongsa/global/util/PageUtil.java
+++ b/src/main/java/com/simbongsa/global/util/PageUtil.java
@@ -1,0 +1,26 @@
+package com.simbongsa.global.util;
+
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class PageUtil {
+
+    public static Boolean hasNextPage(List<?> content, Pageable pageable) {
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            return true;
+        }
+        return false;
+    }
+
+    public static <T> T getLastElement(List<T> list) {
+        if (list.isEmpty()) return null;
+
+        T t = list.get(list.size() - 1);
+
+        return t;
+    }
+
+}


### PR DESCRIPTION
## 구현 목록 🐞
- pageable을 통한 리스트 조회 시 사용하는 hasNextPage()
- pageable을 통한 리스트 반환 시 사용하는 ...PageRes에서 last...Id를 반환하는 getLastId()
- 도메인마다 중복되던 위 메소드들을 PageUtil을 통해 실행될 수 있도록 개선

## 이슈 🎏 
- 스프링 빈이 아닌 static 메소드를 통해 호출
    - 해당 메소드에서 객체를 생성하지 않고 다른 객체, 파일과의 의존성이 없음
    - @Component로 등록해서 사용할 경우 record에서 @autoWired를 사용하지 못해 bean 객체를 가져오는 방법이 번거로움
- 깔끔하게 id까지 받아오고 싶었지만 PageUtil에서는 제네릭 타입의 실제 타입을 알 수 없어 getId를 호출 불가능